### PR TITLE
feat: Add Polly policies for Keycloak token service

### DIFF
--- a/apps/backend/src/Modules.User/Modules.User.csproj
+++ b/apps/backend/src/Modules.User/Modules.User.csproj
@@ -8,6 +8,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Carter" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.15" />
+		<PackageReference Include="Polly" Version="8.5.2" />
 	</ItemGroup>
 
   <ItemGroup>

--- a/apps/backend/src/Shared/ZenFlow.Shared/Infrastructure/AppBuilderExtensions.cs
+++ b/apps/backend/src/Shared/ZenFlow.Shared/Infrastructure/AppBuilderExtensions.cs
@@ -1,10 +1,8 @@
-﻿using Carter;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
-using System.Reflection;
 using ZenFlow.Shared.Application.Auth;
 using ZenFlow.Shared.Infrastructure.Auth;
 

--- a/apps/backend/src/Shared/ZenFlow.Shared/ZenFlow.Shared.csproj
+++ b/apps/backend/src/Shared/ZenFlow.Shared/ZenFlow.Shared.csproj
@@ -14,6 +14,7 @@
 		<PrivateAssets>all</PrivateAssets>
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
+
 	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageReference Include="MediatR" Version="12.5.0" />
 	<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.15" />


### PR DESCRIPTION
This pull request introduces enhancements to the `UserModule` in the backend application by adding retry and circuit breaker policies for the `KeycloakTokenService`, along with some minor cleanup and dependency updates. The most significant changes include the implementation of Polly-based resilience policies, updates to project dependencies, and the removal of unused imports.

### Enhancements to resilience and error handling:

* [`apps/backend/src/Modules.User/Infrastructure/UserModuleExtensions.cs`](diffhunk://#diff-91a434bbd25946fc64ce746e6758d83da88357ec03589b756e37df247b2ba991R26-R30): Added retry and circuit breaker policies for the `KeycloakTokenService` using Polly. This includes the `GetRetryPolicy` and `GetCircuitBreakerPolicy` methods to handle transient HTTP errors and improve service reliability. [[1]](diffhunk://#diff-91a434bbd25946fc64ce746e6758d83da88357ec03589b756e37df247b2ba991R26-R30) [[2]](diffhunk://#diff-91a434bbd25946fc64ce746e6758d83da88357ec03589b756e37df247b2ba991R71-R85)

### Dependency updates:

* [`apps/backend/src/Modules.User/Modules.User.csproj`](diffhunk://#diff-eab3301d8d35e3021b75eb81badc9bfbc125b93ad18c8fc742edb3c1b1ea58c7R11-R12): Added `Microsoft.Extensions.Http.Polly` and `Polly` packages to support the new resilience policies.

### Code cleanup:

* [`apps/backend/src/Shared/ZenFlow.Shared/Infrastructure/AppBuilderExtensions.cs`](diffhunk://#diff-d3fe65acad2c3358155f9e35d9b62ae5d1d8fdbc153cc1431c77d8698b69a315L1-L7): Removed unused imports, such as `Carter` and `System.Reflection`, to streamline the code.

### Minor changes:

* [`apps/backend/src/Shared/ZenFlow.Shared/ZenFlow.Shared.csproj`](diffhunk://#diff-3ff965b688aef0cd12b7057016be60aacab8ccd15477a2a3781b07a306e4e7f2R17): Added a blank line for formatting consistency.